### PR TITLE
Busybox: hush shell, a few applets and basic interop stubs

### DIFF
--- a/pkg/busybox/BUILD.bazel
+++ b/pkg/busybox/BUILD.bazel
@@ -25,11 +25,17 @@ EM_ARGS = {
     "OBJDUMP": "${EMSCRIPTEN}/../bin/llvm-objdump",
     "SKIP_STRIP": "y",
     "CFLAGS_busybox": '"{}"'.format(" ".join([
+        # See: https://github.com/emscripten-core/emscripten/issues/20753
+        "${EMSCRIPTEN}/system/lib/libc/musl/src/signal/sigisemptyset.c",
+        "--pre-js=${EXT_BUILD_ROOT}/$(execpath //pkg/busybox/interop:pre_js)",
+        "--post-js=${EXT_BUILD_ROOT}/$(execpath //pkg/busybox/interop:post_js)",
         "-sEXPORT_ES6",
         "-sMODULARIZE",
         "-sWASM_BIGINT",
     ])),
 }
+
+CONFIG = "//pkg/busybox/config"
 
 configure_make(
     name = "busybox.build",
@@ -37,7 +43,14 @@ configure_make(
         "@platforms//cpu:wasm32": keyval(ARGS, EM_ARGS),
         "//conditions:default": keyval(ARGS, K8_ARGS),
     }),
-    build_data = ["//pkg/busybox/config"],
+    # TODO: select() for :JS inputs!
+    build_data = [
+        CONFIG,
+        "//pkg/busybox/interop:pre_js",
+        "//pkg/busybox/interop:post_js",
+    ],
+    # TODO: Update the configure patch,
+    # so that it would update CFLAGS, LDFLAGS, etc. in the config file.
     configure_in_place = True,
     env = {"CONFIG": "$(execpath //pkg/busybox/config)"},
     lib_source = "@busybox_src//:all",

--- a/pkg/busybox/BUILD.bazel
+++ b/pkg/busybox/BUILD.bazel
@@ -37,9 +37,9 @@ configure_make(
         "@platforms//cpu:wasm32": keyval(ARGS, EM_ARGS),
         "//conditions:default": keyval(ARGS, K8_ARGS),
     }),
-    build_data = ["//pkg/busybox/config:base"],
+    build_data = ["//pkg/busybox/config"],
     configure_in_place = True,
-    env = {"CONFIG": "$(execpath //pkg/busybox/config:base)"},
+    env = {"CONFIG": "$(execpath //pkg/busybox/config)"},
     lib_source = "@busybox_src//:all",
     out_binaries = select({
         "@platforms//cpu:wasm32": [

--- a/pkg/busybox/config/BUILD.bazel
+++ b/pkg/busybox/config/BUILD.bazel
@@ -1,19 +1,18 @@
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 load(":busybox_config.bzl", "busybox_config")
 
+package(default_visibility = ["//pkg/busybox:__pkg__"])
+
 # Absolute minimum configuration.
 # This builds an empty BusyBox that prints "no applets enabled".
 busybox_config(
-    name = "empty",
-    base = ":all_no",
-    remove = [
-        "install_applet_symlinks",
-        "sh_is_ash",
-        "shell_ash",
-    ],
+    name = "config",
+    base = ":base",
     values = {
-        "install_applet_dont": "y",
-        "sh_is_none": "y",
+        # Applets:
+        "false": "y",
+        "true": "y",
+        "yes": "y",
     },
 )
 
@@ -29,7 +28,22 @@ busybox_config(
         # Otherwise compilation fails with BUG_off_t_size_is_misdetected.
         "lfs": "y",
     },
-    visibility = ["//pkg/busybox:__pkg__"],
+)
+
+# Absolute minimum configuration.
+# This builds an empty BusyBox that prints "no applets enabled".
+busybox_config(
+    name = "empty",
+    base = ":all_no",
+    remove = [
+        "install_applet_symlinks",
+        "sh_is_ash",
+        "shell_ash",
+    ],
+    values = {
+        "install_applet_dont": "y",
+        "sh_is_none": "y",
+    },
 )
 
 # BusyBox's default "allnoconfig" output.

--- a/pkg/busybox/config/BUILD.bazel
+++ b/pkg/busybox/config/BUILD.bazel
@@ -13,6 +13,18 @@ busybox_config(
         "false": "y",
         "true": "y",
         "yes": "y",
+
+        # Hush shell:
+        "hush": "y",
+        "shell_hush": "y",
+        "feature_sh_nofork": "y",
+        "feature_sh_standalone": "y",
+
+        # Force NOMMU build.
+        # Tells the build system that the target platform has no Memory
+        # Management Unit (MMU). This causes the shell to use vfork() instead
+        # of fork(), which is easier to emulate in the browser.
+        "nommu": "y",
     },
 )
 

--- a/pkg/busybox/interop/BUILD
+++ b/pkg/busybox/interop/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//pkg/busybox:__pkg__"])
+
+filegroup(
+    name = "pre_js",
+    srcs = ["pre.js"],
+)
+
+filegroup(
+    name = "post_js",
+    srcs = ["post.js"],
+)

--- a/pkg/busybox/interop/post.js
+++ b/pkg/busybox/interop/post.js
@@ -1,0 +1,10 @@
+console.log("post.js");
+
+ENV["USER"] = Module.user;
+FS.rename("/home/web_user", `/home/${Module.user}`);
+
+const _get_char = FS_stdin_getChar;
+FS_stdin_getChar = () => {
+  console.log("TODO: get_char()!");
+  return _get_char();
+};

--- a/pkg/busybox/interop/pre.js
+++ b/pkg/busybox/interop/pre.js
@@ -1,0 +1,5 @@
+console.log("pre.js");
+
+Module.onRuntimeInitialized = () => {
+  console.log("init");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl SnailOs {
         self.term.writeln("Loading BusyBox shell…")?;
         self.term.writeln("")?;
 
-        let pid = self.proc.exec("/bin/busybox").await?;
+        let pid = self.proc.exec("/bin/busybox", &["hush"]).await?;
         while let Some(output) = self.proc.wait_output(pid).await? {
             for chunk in output {
                 self.term.write(&chunk.as_string().unwrap())?;

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -55,7 +55,7 @@ impl ProcessManager {
 
     /// Executes the given binary file.
     /// Once the process has started, returns its pid.
-    pub async fn exec(&mut self, file_path: &str) -> Result<u32, Error> {
+    pub async fn exec(&mut self, file_path: &str, args: &[&str]) -> Result<u32, Error> {
         let resolved_path = self
             .binfs
             .resolve(file_path)
@@ -72,7 +72,7 @@ impl ProcessManager {
                 .unwrap() // already validated above
                 .to_string_lossy()
                 .to_string(),
-            &[],
+            args,
             self.p_defer.clone(),
         )?;
 
@@ -154,6 +154,9 @@ impl Process {
         Reflect::set(&mod_args, &"print".into(), &print.as_ref())?;
         Reflect::set(&mod_args, &"printErr".into(), &print_err.as_ref())?;
         Reflect::set(&mod_args, &"quit".into(), &quit.as_ref())?;
+
+        // Variables used in post.js.
+        Reflect::set(&mod_args, &"user".into(), &"snail".into())?;
 
         let promise: Promise = module.call1(&JsValue::null(), &mod_args)?.into();
         let future = JsFuture::from(promise);


### PR DESCRIPTION
Add some applets, a very basic (currently still defunct) shell, and hooks for implementing basic I/O.

Still not very function as `vfork` and `waitpid` stubs are not ready, but the files and the basic config is there and it builds.